### PR TITLE
Patch for Tutorial Crashes

### DIFF
--- a/toontown/quest/QuestParser.py
+++ b/toontown/quest/QuestParser.py
@@ -713,9 +713,29 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         quitButton, extraChatFlags, dialogueList = self.parseExtraChatArgs(line[4:])
         return Func(avatar.setLocalPageChat, chatString, quitButton, extraChatFlags, dialogueList)
 
-   
+    def parseCCChatConfirm(self, line) -> Func:
+        lineLength = len(line)
+        avatarName = line[1]
+        avatar = self.getVar(avatarName)
+        chatString = eval('TTLocalizer.' + line[2] % 'Mickey')
+        quitButton, extraChatFlags, dialogueList = self.parseExtraChatArgs(line[3:])
+        return Func(avatar.setLocalPageChat, chatString, quitButton, extraChatFlags, dialogueList)
 
-
+    def parseCCChatToConfirm(self, line):
+        lineLength = len(line)
+        avatarKey = line[1]
+        avatar = self.getVar(avatarKey)
+        toAvatarKey = line[2]
+        toAvatar = self.getVar(toAvatarKey)
+        localizerAvatarName = toAvatar.getName().capitalize()
+        toAvatarName = eval('TTLocalizer.' + localizerAvatarName)
+        if toAvatar.getName() == 'Mickey':
+            chatString = eval('TTLocalizer.' + line[3] % 'Mickey')
+        else:
+            chatString = eval('TTLocalizer.' + line[3] % 'Minnie')
+        chatString = chatString.replace('%s', toAvatarName)
+        quitButton, extraChatFlags, dialogueList = self.parseExtraChatArgs(line[4:])
+        return Func(avatar.setLocalPageChat, chatString, quitButton, extraChatFlags, dialogueList)
 
     def parsePlaySfx(self, line):
         if len(line) == 2:

--- a/toontown/quest/QuestParser.py
+++ b/toontown/quest/QuestParser.py
@@ -717,7 +717,11 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         lineLength = len(line)
         avatarName = line[1]
         avatar = self.getVar(avatarName)
-        chatString = eval('TTLocalizer.' + line[2] % 'Mickey')
+        notify.info("MickeyNameConfirm, "+avatar.getName())
+        if avatar.getName() == 'mickey':
+            chatString = eval('TTLocalizer.' + line[2] % 'Mickey')
+        else:
+            chatString = eval('TTLocalizer.' + line[2] % 'Minnie')
         quitButton, extraChatFlags, dialogueList = self.parseExtraChatArgs(line[3:])
         return Func(avatar.setLocalPageChat, chatString, quitButton, extraChatFlags, dialogueList)
 
@@ -729,7 +733,7 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         toAvatar = self.getVar(toAvatarKey)
         localizerAvatarName = toAvatar.getName().capitalize()
         toAvatarName = eval('TTLocalizer.' + localizerAvatarName)
-        if toAvatar.getName() == 'Mickey':
+        if toAvatar.getName() == 'mickey':
             chatString = eval('TTLocalizer.' + line[3] % 'Mickey')
         else:
             chatString = eval('TTLocalizer.' + line[3] % 'Minnie')

--- a/toontown/quest/QuestParser.py
+++ b/toontown/quest/QuestParser.py
@@ -717,7 +717,6 @@ class NPCMoviePlayer(DirectObject.DirectObject):
         lineLength = len(line)
         avatarName = line[1]
         avatar = self.getVar(avatarName)
-        notify.info("MickeyNameConfirm, "+avatar.getName())
         if avatar.getName() == 'mickey':
             chatString = eval('TTLocalizer.' + line[2] % 'Mickey')
         else:


### PR DESCRIPTION
Noticed when making a new toon the game crashed immediately when loading tutorial so I re-implemented the missing parseCCChatConfirm and parseCCChatToConfirm in quest parser (minus the toon gender check)

Old code w/check:
![image](https://github.com/user-attachments/assets/b9fa41fc-924e-4b34-9599-7530aa49d3bc)

New code w/o check
![image](https://github.com/user-attachments/assets/aaf75220-a3c3-475c-a961-1085f468c1c1)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `parseCCChatConfirm` and `parseCCChatToConfirm` methods to handle local page chat parsing with specific avatar conditions.

### Why are these changes being made?

These changes address tutorial crashes by providing additional chat parsing functions that account for specific conditions related to avatar names; particularly, handling chat patterns for avatars 'mickey' and 'minnie' using localization strings and ensuring chat content is correctly formatted and displayed.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->